### PR TITLE
Separate out variables from main terraform process

### DIFF
--- a/aws-ec2-with-eip/README.md
+++ b/aws-ec2-with-eip/README.md
@@ -26,3 +26,10 @@ with this file directly; Terraform handles this process for us.<br/>
 **6)**. Writes the Elastic IP address to a text file. After you successfully run the ```terraform apply``` command <br />
 you can copy and paste that elastic IP from the text file into your web browser, where you will then be able to access a web page <br />
 hosted on that web browser.
+
+## Optional
+Create a file called "terraform.tfvars" and define the ssh_priv_key_path and ssh_pub_key_path variables:
+```
+ssh_priv_key_path = "path/to/your/priv_key"
+ssh_pub_key_path = "path/to/your/pub_key.pub"
+```

--- a/aws-ec2-with-eip/aws-ec2-with-eip.tf
+++ b/aws-ec2-with-eip/aws-ec2-with-eip.tf
@@ -1,11 +1,11 @@
 provider "aws" {
   profile = "default"
-  region  = "us-east-1"
+  region  = var.region
 }
 
 resource "aws_instance" "webserver" {
   key_name        = aws_key_pair.kp.key_name
-  ami             = "ami-09d95fab7fff3776c" # Linux AMI 2 in us-east-1
+  ami             = var.ami_map[var.region]
   instance_type   = "t2.micro"
   security_groups = ["${aws_security_group.WebServerSG.name}"]
 
@@ -13,7 +13,7 @@ resource "aws_instance" "webserver" {
     type        = "ssh"
     user        = "ec2-user"
     host        = self.public_ip
-    private_key = file("C:/Users/jay.jain/.ssh/terraform")
+    private_key = file(var.ssh_priv_key_path)
   }
 
   provisioner "remote-exec" {
@@ -27,38 +27,38 @@ resource "aws_instance" "webserver" {
 }
 
 resource "aws_key_pair" "kp" {
-  key_name = "ouroboros"  
-  public_key = file("C:/Users/jay.jain/.ssh/terraform.pub")
+  key_name   = "ouroboros"
+  public_key = file(var.ssh_pub_key_path)
 }
 
 resource "aws_eip" "ip" {
   vpc      = true
   instance = aws_instance.webserver.id
 
-  provisioner "local-exec" {    
-    command = "echo 'The Elastic IP of your web server is: ' ${aws_eip.ip.public_ip} > ip_address.txt"
+  provisioner "local-exec" {
+    command = "echo The Elastic IP of your web server is: ${aws_eip.ip.public_ip} > ip_address.txt"
   }
 }
 
 resource "aws_security_group" "WebServerSG" {
   name        = "WebServerSG"
-  description = "Allows inbound HTTP traffic and SSH traffic"  
+  description = "Allows inbound HTTP traffic and SSH traffic"
 
   ingress {
-    description     = "HTTP"
-    from_port       = 80
-    to_port         = 80
-    protocol        = "tcp"
-    cidr_blocks     = ["0.0.0.0/0"]
+    description      = "HTTP"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description     = "SSH"
-    from_port       = 22
-    to_port         = 22
-    protocol        = "tcp"
-    cidr_blocks     = ["0.0.0.0/0"]
+    description      = "SSH"
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
 

--- a/aws-ec2-with-eip/variables.tf
+++ b/aws-ec2-with-eip/variables.tf
@@ -1,0 +1,23 @@
+variable "region" {
+  type        = string
+  default     = "us-east-1"
+  description = "Region in which the EC2 instance will run"
+}
+
+variable "ami_map" {
+  type = map(string)
+  description = "Map of AMIs and their regions"
+  default = {
+    us-east-1 = "ami-09d95fab7fff3776c"
+  }
+}
+
+variable "ssh_priv_key_path" {
+  type        = string
+  description = "Path to local ssh private key for ssh authentication"
+}
+
+variable "ssh_pub_key_path" {
+  type        = string
+  description = "Path to local ssh public key for ssh authentication"
+}

--- a/aws-ec2-without-eip/README.md
+++ b/aws-ec2-without-eip/README.md
@@ -3,3 +3,10 @@ This script launches an EC2 instance without and elastic IP. It uses just the de
 The static IP is written to a file called ```ip_address.txt``` which you can visit in your browser to test that the nginx server works.<br>
 To run this script, read the README in the index of this repository.
 **Make sure you run ``` terraform destroy ``` after you are done with this example.**
+
+## Optional
+Create a file called "terraform.tfvars" and define the ssh_priv_key_path and ssh_pub_key_path variables:
+```
+ssh_priv_key_path = "path/to/your/priv_key"
+ssh_pub_key_path = "path/to/your/pub_key.pub"
+```

--- a/aws-ec2-without-eip/aws-ec2-without-eip.tf
+++ b/aws-ec2-without-eip/aws-ec2-without-eip.tf
@@ -1,11 +1,11 @@
 provider "aws" {
   profile = "default"
-  region  = "us-east-1"
+  region  = var.region
 }
 
 resource "aws_instance" "webserver" {
   key_name        = aws_key_pair.kp.key_name
-  ami             = "ami-09d95fab7fff3776c" # Linux AMI 2 in us-east-1
+  ami             = var.ami_map[var.region]
   instance_type   = "t2.micro"
   security_groups = ["${aws_security_group.WebServerSG.name}"]
 
@@ -13,7 +13,7 @@ resource "aws_instance" "webserver" {
     type        = "ssh"
     user        = "ec2-user"
     host        = self.public_ip
-    private_key = file("C:/Users/jay.jain/.ssh/terraform")
+    private_key = file(var.ssh_priv_key_path)
   }
 
   provisioner "remote-exec" {
@@ -25,14 +25,14 @@ resource "aws_instance" "webserver" {
     ]
   }
 
-  provisioner "local-exec" {    
-    command = "echo 'The temporary static IP of your web server is: ' ${aws_instance.webserver.public_ip} > ip_address.txt"
+  provisioner "local-exec" {
+    command = "echo The temporary static IP of your web server is: ${aws_instance.webserver.public_ip} > ip_address.txt"
   }
 }
 
 resource "aws_key_pair" "kp" {
-  key_name = "ouroboros"  
-  public_key = file("C:/Users/jay.jain/.ssh/terraform.pub")
+  key_name   = "ouroboros"
+  public_key = file(var.ssh_pub_key_path)
 
 }
 

--- a/aws-ec2-without-eip/variables.tf
+++ b/aws-ec2-without-eip/variables.tf
@@ -1,0 +1,23 @@
+variable "region" {
+  type        = string
+  default     = "us-east-1"
+  description = "Region in which the EC2 instance will run"
+}
+
+variable "ami_map" {
+  type        = map(string)
+  description = "Map of AMIs and their regions"
+  default = {
+    us-east-1 = "ami-09d95fab7fff3776c"
+  }
+}
+
+variable "ssh_priv_key_path" {
+  type        = string
+  description = "Path to local ssh private key for ssh authentication"
+}
+
+variable "ssh_pub_key_path" {
+  type        = string
+  description = "Path to local ssh public key for ssh authentication"
+}


### PR DESCRIPTION
Variables for region, AMI, and ssh keys separated out into `variables.tf` files.

Included an OPTIONAL header on READMEs for setting a `tfvars` file to skip prompts for SSH key paths.

Also fixed the formatting of the echo statement when generating the ip_address.txt file.